### PR TITLE
Add thepetk/registry to config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,6 +38,7 @@ module.exports = {
     "arcalot/arcaflow-plugin-minio",
     "arcalot/arcaflow-plugin-iperf3",
     "arcalot/arcaflow-plugin-smallfile",
-    "crc-org/crc-cloud"
+    "crc-org/crc-cloud",
+    "thepetk/registry"
   ]
 };


### PR DESCRIPTION
## Pull request details

The repo https://github.com/thepetk/registry is a fork of the devfiles org repo https://github.com/devfile/registry

**This PR temporarily adds the fork to config.js** in order to test the self hosted renovate runner with our configuration.

I've already invited the platform-engineering-bot to this repo (invite is pending)

## Related issues

Partially fixes https://github.com/devfile/api/issues/1202