### PR TITLE
Remove thepetk registry from config-other

### DIFF
--- a/config-other.js
+++ b/config-other.js
@@ -18,7 +18,6 @@ module.exports = {
   repositories: [
     "crc-org/crc-cloud",
     "devfile/registry",
-    "thepetk/registry",
     "ralphbean/dnf-plugin-lockfile",
     "kubevirt/hyperconverged-cluster-operator",
     "lmilbaum/hyperconverged-cluster-operator"


### PR DESCRIPTION
## What does this PR do?

Removes the `thepetk/registry` repo from the runner configuration. This repo has been added in order to test the `devfile/registry` configuration.

## Which issue(s) does this PR fix
N/A