### PR TITLE
Enable renovate-test and renovate_test_2

### DIFF
--- a/config-other.js
+++ b/config-other.js
@@ -20,7 +20,9 @@ module.exports = {
     "crc-org/crc-cloud",
     "devfile/registry",
     "ralphbean/dnf-plugin-lockfile",
-    "kubevirt/hyperconverged-cluster-operator"
+    "kubevirt/hyperconverged-cluster-operator",
+    "platform-engineering-org-test/renovate-test",
+    "platform-engineering-org-test/renovate_test_2"
   ],
   constraints: {
     go: "1.19"


### PR DESCRIPTION
renovate-test and renovate_test_2 were moved to a new namespace. They used to be automatically selected by renovate-runner in autodiscover mode since they were part of the
platform-engineering-org namespace. Since we moved them to a new namespace we now need to explicitly define them in the configuration for renovate-runner to be able to detect them.